### PR TITLE
remove mordilion/mutils dependency, use native PHP sort functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
-        "mordilion/mutils": "^1.2"
+        "php": ">=8.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/src/Dictionary.php
+++ b/src/Dictionary.php
@@ -15,7 +15,6 @@ namespace Mordilion\HuffmanPHP;
 
 use InvalidArgumentException;
 use Mordilion\HuffmanPHP\Dictionary\Occurrence;
-use MUtils\Arrays;
 
 /**
  * @author Henning Huncke <mordilion@gmx.de>
@@ -177,11 +176,11 @@ class Dictionary
     {
         $this->valuesReversed = $this->values;
 
-        Arrays\uksort($this->values, static function ($left, $right) {
+        uksort($this->values, static function ($left, $right) {
             return strlen((string) $right) <=> strlen((string) $left);
         });
 
-        Arrays\uasort($this->valuesReversed, static function ($left, $right) {
+        uasort($this->valuesReversed, static function ($left, $right) {
             return strlen((string) $left) <=> strlen((string) $right);
         });
 
@@ -203,7 +202,7 @@ class Dictionary
 
     private function sortByCountAndDepth(array &$occurrences): void
     {
-        Arrays\usort($occurrences, static function (Occurrence $left, Occurrence $right) {
+        usort($occurrences, static function (Occurrence $left, Occurrence $right) {
             $compare = $left->getCount() <=> $right->getCount();
 
             if ($compare !== 0) {


### PR DESCRIPTION
The mutils package only provided wrappers around native uksort, uasort, and usort functions. With PHP 8.1+ as minimum version, there is no need for this polyfill dependency.